### PR TITLE
Add UNIT_SWEEP as an alias for UnitSweep (#6518)

### DIFF
--- a/cirq-core/cirq/__init__.py
+++ b/cirq-core/cirq/__init__.py
@@ -509,6 +509,7 @@ from cirq.study import (
     to_sweeps,
     Result,
     UnitSweep,
+    UNIT_SWEEP,
     Zip,
     ZipLongest,
 )

--- a/cirq-core/cirq/protocols/json_test_data/spec.py
+++ b/cirq-core/cirq/protocols/json_test_data/spec.py
@@ -109,6 +109,7 @@ TestSpec = ModuleJsonTestSpec(
         'StateVectorStepResult',
         'StepResultBase',
         'UnitSweep',
+        'UNIT_SWEEP',
         'NamedTopology',
         # protocols:
         'HasJSONNamespace',

--- a/cirq-core/cirq/study/__init__.py
+++ b/cirq-core/cirq/study/__init__.py
@@ -36,6 +36,7 @@ from cirq.study.sweeps import (
     Points,
     Product,
     Sweep,
+    UNIT_SWEEP,
     UnitSweep,
     Zip,
     ZipLongest,

--- a/cirq-core/cirq/study/sweeps.py
+++ b/cirq-core/cirq/study/sweeps.py
@@ -205,6 +205,10 @@ class _Unit(Sweep):
 UnitSweep = _Unit()
 document(UnitSweep, """The singleton sweep with no parameters.""")
 
+# Alternate name to designate as a constant.
+UNIT_SWEEP = UnitSweep
+document(UNIT_SWEEP, """The singleton sweep with no parameters.""")
+
 
 class Product(Sweep):
     """Cartesian product of one or more sweeps.

--- a/cirq-core/cirq/study/sweeps_test.py
+++ b/cirq-core/cirq/study/sweeps_test.py
@@ -232,6 +232,9 @@ def test_equality():
 
     et.add_equality_group(cirq.UnitSweep, cirq.UnitSweep)
 
+    # Test singleton
+    assert cirq.UNIT_SWEEP is cirq.UnitSweep
+
     # Simple sweeps with the same key are equal to themselves, but different
     # from each other even if they happen to contain the same points.
     et.make_equality_group(lambda: cirq.Linspace('a', 0, 10, 11))


### PR DESCRIPTION
Since this is a singleton, it should use constant naming. Since it should also stay consistent with other Sweeps (and for backwards compatibility), we will keep the old name as well.

Fixes: #5617